### PR TITLE
URL-safe base64 encodings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5952,6 +5952,7 @@
       "resolved": "https://registry.npmjs.org/re2/-/re2-1.15.9.tgz",
       "integrity": "sha512-AXWEhpMTBdC+3oqbjdU07dk0pBCvxh5vbOMLERL6Y8FYBSGn4vXlLe8cYszn64Yy7H8keVMrgPzoSvOd4mePpg==",
       "dev": true,
+      "hasInstallScript": true,
       "optional": true,
       "dependencies": {
         "install-artifact-from-github": "^1.2.0",

--- a/src/main.js
+++ b/src/main.js
@@ -67,7 +67,10 @@ share.onclick = async () => {
   const p = new URLSearchParams(u.search);
   const { default: deflate } = await import("./deflate.js");
   const payload = btoa(deflate(code.value, 9));
-  p.set("zcode", payload);
+  // change letters around so payload can be put in a url
+  // padding is not needed
+  const safePayload = payload.replaceAll("+", "-").replaceAll("/", "_").replaceAll("=", "");
+  p.set("zcode", safePayload);
   p.delete("code");
   u.search = "?" + p.toString();
   history.replaceState({}, "", u);
@@ -128,7 +131,9 @@ async function main() {
   let lastSource = "";
   let fromURL = false;
   if (p.has("zcode")) {
-    lastSource = inflate(atob(p.get("zcode")));
+    // restore - and _ to + and /
+    const b64 = p.get("zcode").replaceAll("-", "+").replaceAll("_", "/");
+    lastSource = inflate(atob(b64));
     fromURL = true;
   } else if (p.has("code")) {
     lastSource = atob(p.get("code"));

--- a/src/main.js
+++ b/src/main.js
@@ -136,7 +136,7 @@ async function main() {
     lastSource = inflate(atob(b64));
     fromURL = true;
   } else if (p.has("code")) {
-    lastSource = atob(p.get("code"));
+    lastSource = atob(p.get("code").replaceAll("-", "+").replaceAll("_", "/"));
     fromURL = true;
   } else {
     lastSource = await get(IDBKey);


### PR DESCRIPTION
I replaced `+/` with `-_`, respectively, and removed `=` from the base64-encoded data in the share URLs. This makes the URL slightly shorter as `-` and `_` can be stored directly while `+` and `/` must be URL encoded. These strings can go in the same `zcode` querystring parameter, as upon decode I replace `-` and `_` with the standard base64 characters, but I don't change anything else. So URLs that have been created previously are still parsed correctly.

I also added support for the alternative base64 encoding for the uncompressed `code` parameter, for good measure, but that probably won't come up. There's no way in the app to create such a URL, but it will work. :zany_face: